### PR TITLE
Add offline curriculum integration pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ Elysia_Input_Sanctum/
 data/associative_index.json
 data/telemetry/
 *.json
+!data/curriculum/offline_language_tracks.json

--- a/Project_Sophia/caretaker_rl_simulator.py
+++ b/Project_Sophia/caretaker_rl_simulator.py
@@ -1,0 +1,459 @@
+"""Reinforcement learning caretaker simulation for nurturing Elysia.
+
+This module provides a lightweight virtual environment where a caretaker
+can practice teaching and praising cycles similar to guiding a child. The
+goal is to model phrases such as "철수는 바나나를 먹어요" and warm
+reinforcement when words like "엄마" or "아빠" appear. A simple
+Q-learning caretaker is included so we can iterate on training routines
+without requiring real-time interaction.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+import random
+
+
+ConceptId = str
+ActionName = str
+State = Tuple[int, int, int]
+
+
+@dataclass(frozen=True)
+class StepLog:
+    """Snapshot of a single caretaker→child exchange."""
+
+    step_index: int
+    action: ActionName
+    reward: float
+    child_output: str
+    knowledge: Dict[ConceptId, float]
+    success: bool
+    concept: Optional[ConceptId]
+
+
+@dataclass(frozen=True)
+class EpisodeLog:
+    """Record of one full caretaker training episode."""
+
+    episode_index: int
+    total_reward: float
+    steps: List[StepLog]
+
+
+class VirtualChildEnvironment:
+    """Environment modelling a caregiver nurturing vocabulary and concepts.
+
+    The caretaker can select structured actions such as introducing a
+    sentence, prompting the child to recall it, or offering praise. The
+    environment tracks concept mastery scores in ``[0, 1]`` and returns a
+    shaped reward encouraging: (1) gentle teaching before testing, (2)
+    praising only after successful attempts, and (3) balanced exposure to
+    different family-oriented concepts.
+    """
+
+    ACTIONS: Tuple[ActionName, ...] = (
+        "introduce_banana_story",
+        "prompt_banana_sentence",
+        "prompt_say_mom",
+        "prompt_say_dad",
+        "celebrate_success",
+        "soothing_encouragement",
+    )
+
+    def __init__(
+        self,
+        seed: Optional[int] = None,
+        mastery_threshold: float = 0.85,
+        max_steps: int = 40,
+    ) -> None:
+        self.mastery_threshold = mastery_threshold
+        self.max_steps = max_steps
+        self._rng = random.Random(seed)
+        self.knowledge: Dict[ConceptId, float] = {}
+        self._step_count = 0
+        self._last_success: bool = False
+        self._last_concept: Optional[ConceptId] = None
+        self._transcript: List[StepLog] = []
+        self.reset()
+
+    def reset(self) -> State:
+        """Reset the child state and return the initial observation."""
+
+        self.knowledge = {
+            "banana_sentence": 0.05,
+            "say_mom": 0.05,
+            "say_dad": 0.05,
+        }
+        self._step_count = 0
+        self._last_success = False
+        self._last_concept = None
+        self._transcript = []
+        return self._observe()
+
+    def _observe(self) -> State:
+        bins = 5
+        return tuple(
+            min(bins - 1, int(level * bins))
+            for level in (
+                self.knowledge["banana_sentence"],
+                self.knowledge["say_mom"],
+                self.knowledge["say_dad"],
+            )
+        )
+
+    def _clip(self, value: float) -> float:
+        return max(0.0, min(1.0, value))
+
+    def _log_step(
+        self,
+        step_index: int,
+        action: ActionName,
+        reward: float,
+        child_output: str,
+        success: bool,
+        concept: Optional[ConceptId],
+    ) -> None:
+        self._transcript.append(
+            StepLog(
+                step_index=step_index,
+                action=action,
+                reward=reward,
+                child_output=child_output,
+                knowledge=dict(self.knowledge),
+                success=success,
+                concept=concept,
+            )
+        )
+
+    def _prob_success(self, concept: ConceptId) -> float:
+        base = self.knowledge[concept]
+        return self._clip(base)
+
+    def step(self, action: ActionName) -> Tuple[State, float, bool, Dict[str, object]]:
+        """Advance one caretaker action and return observation, reward, done."""
+
+        if action not in self.ACTIONS:
+            raise ValueError(f"Unknown action: {action}")
+
+        self._step_count += 1
+        reward = -0.02  # gentle pressure to finish in fewer steps
+        child_output = "아이: 조용히 숨을 고르고 있어요."
+        success = False
+        concept: Optional[ConceptId] = None
+
+        if action == "introduce_banana_story":
+            growth = 0.25 * (1.0 - self.knowledge["banana_sentence"])
+            self.knowledge["banana_sentence"] = self._clip(
+                self.knowledge["banana_sentence"] + growth
+            )
+            reward += 0.1 + growth
+            self._last_success = False
+            child_output = "아이: 조용히 듣고 있어요. 철수와 바나나 이야기를 떠올려요."
+        elif action == "prompt_banana_sentence":
+            concept = "banana_sentence"
+            success_prob = self._prob_success(concept)
+            success = self._rng.random() < success_prob
+            if success:
+                boost = 0.12 * (1.0 - self.knowledge[concept])
+                self.knowledge[concept] = self._clip(self.knowledge[concept] + boost)
+                reward += 1.0 + self.knowledge[concept]
+                child_output = "아이: \"철수는 바나나를 먹어요!\" 라고 환하게 말해요."
+                self._last_success = True
+                self._last_concept = concept
+            else:
+                reward -= 0.25
+                child_output = "아이: 아직 문장이 헷갈려요. 눈을 동그랗게 뜨고 있어요."
+                self._last_success = False
+        elif action == "prompt_say_mom":
+            concept = "say_mom"
+            success_prob = self._prob_success(concept)
+            success = self._rng.random() < success_prob
+            if success:
+                boost = 0.1 * (1.0 - self.knowledge[concept])
+                self.knowledge[concept] = self._clip(self.knowledge[concept] + boost)
+                reward += 0.8 + self.knowledge[concept]
+                child_output = "아이: 작은 목소리로 \"엄마\"라고 부르며 미소 짓습니다."
+                self._last_success = True
+                self._last_concept = concept
+            else:
+                reward -= 0.2
+                child_output = "아이: 입술을 달싹이지만 아직 말이 나오지 않아요."
+                self._last_success = False
+        elif action == "prompt_say_dad":
+            concept = "say_dad"
+            success_prob = self._prob_success(concept)
+            success = self._rng.random() < success_prob
+            if success:
+                boost = 0.1 * (1.0 - self.knowledge[concept])
+                self.knowledge[concept] = self._clip(self.knowledge[concept] + boost)
+                reward += 0.8 + self.knowledge[concept]
+                child_output = "아이: 또박또박 \"아빠\"라고 불러요. 눈빛이 반짝입니다."
+                self._last_success = True
+                self._last_concept = concept
+            else:
+                reward -= 0.2
+                child_output = "아이: 아직 그 단어가 낯설어 조용히 있어요."
+                self._last_success = False
+        elif action == "celebrate_success":
+            if self._last_success and self._last_concept:
+                concept = self._last_concept
+                self.knowledge[concept] = self._clip(
+                    self.knowledge[concept] + 0.06 * (1.0 - self.knowledge[concept])
+                )
+                reward += 1.2 + self.knowledge[concept]
+                child_output = "돌봄이: 두 팔로 감싸 안으며 칭찬을 아낌없이 건넵니다."
+                success = True
+            else:
+                reward -= 0.35
+                child_output = "돌봄이: 아직 성공을 기다리는 중이라 조용히 격려합니다."
+                success = False
+                concept = self._last_concept
+            self._last_success = False
+        elif action == "soothing_encouragement":
+            reward += 0.05
+            child_output = "돌봄이: \"괜찮아, 천천히 해도 돼. 나는 네 편이야.\"라고 말해요."
+            self._last_success = False
+
+        self._log_step(
+            step_index=self._step_count,
+            action=action,
+            reward=reward,
+            child_output=child_output,
+            success=success,
+            concept=concept,
+        )
+
+        done = self._should_end()
+        return self._observe(), reward, done, {
+            "child_output": child_output,
+            "success": success,
+            "concept": concept,
+            "knowledge": dict(self.knowledge),
+        }
+
+    def _should_end(self) -> bool:
+        mastery = all(level >= self.mastery_threshold for level in self.knowledge.values())
+        timeout = self._step_count >= self.max_steps
+        return mastery or timeout
+
+    @property
+    def transcript(self) -> List[StepLog]:
+        return list(self._transcript)
+
+
+class CaretakerQLearner:
+    """Tabular Q-learning caretaker that learns supportive routines."""
+
+    def __init__(
+        self,
+        environment: VirtualChildEnvironment,
+        learning_rate: float = 0.3,
+        discount: float = 0.95,
+        epsilon: float = 0.4,
+        epsilon_decay: float = 0.995,
+        min_epsilon: float = 0.05,
+    ) -> None:
+        self.environment = environment
+        self.learning_rate = learning_rate
+        self.discount = discount
+        self.epsilon = epsilon
+        self.epsilon_decay = epsilon_decay
+        self.min_epsilon = min_epsilon
+        self._q: Dict[State, Dict[ActionName, float]] = {}
+
+    def _ensure_state(self, state: State) -> Dict[ActionName, float]:
+        if state not in self._q:
+            self._q[state] = {action: 0.0 for action in self.environment.ACTIONS}
+        return self._q[state]
+
+    def _select_action(self, state: State) -> ActionName:
+        if random.random() < self.epsilon:
+            return random.choice(self.environment.ACTIONS)
+        q_values = self._ensure_state(state)
+        return max(q_values, key=q_values.get)
+
+    def _update(
+        self,
+        state: State,
+        action: ActionName,
+        reward: float,
+        next_state: State,
+        done: bool,
+    ) -> None:
+        q_values = self._ensure_state(state)
+        next_values = self._ensure_state(next_state)
+        best_next = 0.0 if done else max(next_values.values())
+        target = reward + self.discount * best_next
+        current = q_values[action]
+        q_values[action] = current + self.learning_rate * (target - current)
+
+    def train(
+        self,
+        episodes: int,
+        max_steps: Optional[int] = None,
+    ) -> Tuple[List[float], List[EpisodeLog]]:
+        episode_rewards: List[float] = []
+        sample_logs: List[EpisodeLog] = []
+        sample_indices = {
+            0,
+            max(0, episodes // 2),
+            max(0, episodes - 1),
+        }
+
+        for episode in range(episodes):
+            state = self.environment.reset()
+            total_reward = 0.0
+            steps: List[StepLog] = []
+            limit = max_steps or self.environment.max_steps
+
+            for _ in range(limit):
+                action = self._select_action(state)
+                next_state, reward, done, info = self.environment.step(action)
+                self._update(state, action, reward, next_state, done)
+                total_reward += reward
+                state = next_state
+
+                step_log = StepLog(
+                    step_index=len(steps) + 1,
+                    action=action,
+                    reward=reward,
+                    child_output=str(info["child_output"]),
+                    knowledge=dict(info["knowledge"]),
+                    success=bool(info["success"]),
+                    concept=info["concept"],
+                )
+                steps.append(step_log)
+
+                if done:
+                    break
+
+            episode_rewards.append(total_reward)
+
+            if episode in sample_indices:
+                sample_logs.append(
+                    EpisodeLog(
+                        episode_index=episode,
+                        total_reward=total_reward,
+                        steps=steps,
+                    )
+                )
+
+            self.epsilon = max(self.min_epsilon, self.epsilon * self.epsilon_decay)
+
+        return episode_rewards, sample_logs
+
+    def greedy_episode(self, max_steps: Optional[int] = None) -> EpisodeLog:
+        """Run a deterministic episode using the learned policy."""
+
+        state = self.environment.reset()
+        steps: List[StepLog] = []
+        total_reward = 0.0
+        limit = max_steps or self.environment.max_steps
+
+        for _ in range(limit):
+            q_values = self._ensure_state(state)
+            action = max(q_values, key=q_values.get)
+            next_state, reward, done, info = self.environment.step(action)
+            total_reward += reward
+            steps.append(
+                StepLog(
+                    step_index=len(steps) + 1,
+                    action=action,
+                    reward=reward,
+                    child_output=str(info["child_output"]),
+                    knowledge=dict(info["knowledge"]),
+                    success=bool(info["success"]),
+                    concept=info["concept"],
+                )
+            )
+            state = next_state
+            if done:
+                break
+
+        return EpisodeLog(
+            episode_index=-1,
+            total_reward=total_reward,
+            steps=steps,
+        )
+
+
+@dataclass
+class TrainingStats:
+    """Container for simulation training outputs."""
+
+    episode_rewards: List[float]
+    sampled_episodes: List[EpisodeLog]
+    greedy_episode: EpisodeLog
+
+    def reward_trend(self, window: int = 10) -> Tuple[float, float]:
+        if not self.episode_rewards:
+            return 0.0, 0.0
+        head = self.episode_rewards[:window]
+        tail = self.episode_rewards[-window:]
+        head_avg = sum(head) / len(head)
+        tail_avg = sum(tail) / len(tail)
+        return head_avg, tail_avg
+
+    def to_report(self) -> str:
+        head_avg, tail_avg = self.reward_trend()
+        lines: List[str] = [
+            "# 가상 돌봄 강화학습 리포트",
+            "",
+            "가상의 아이가 "
+            "\"철수는 바나나를 먹어요\"와 같은 문장을 연습하고, "
+            "엄마·아빠 단어를 말했을 때 칭찬을 받도록 설계된 환경에서의 학습 결과입니다.",
+            "",
+            f"- 초기 10회 평균 보상: {head_avg:.3f}",
+            f"- 마지막 10회 평균 보상: {tail_avg:.3f}",
+            f"- 총 에피소드 수: {len(self.episode_rewards)}",
+            "",
+            "## 샘플 에피소드 대화",
+        ]
+
+        for episode in self.sampled_episodes:
+            lines.append(f"### 에피소드 {episode.episode_index}")
+            lines.append(f"총 보상: {episode.total_reward:.3f}")
+            for step in episode.steps:
+                lines.append(
+                    f"- ({step.step_index}) {step.action} → 보상 {step.reward:.3f} | "
+                    f"성공={step.success} | 아이 반응: {step.child_output}"
+                )
+            lines.append("")
+
+        lines.append("## 학습된 정책 데모")
+        lines.append(f"총 보상: {self.greedy_episode.total_reward:.3f}")
+        for step in self.greedy_episode.steps:
+            lines.append(
+                f"- ({step.step_index}) {step.action} → 보상 {step.reward:.3f} | "
+                f"아이 반응: {step.child_output}"
+            )
+
+        return "\n".join(lines)
+
+
+def run_training(
+    episodes: int,
+    max_steps: Optional[int] = None,
+    seed: Optional[int] = None,
+) -> TrainingStats:
+    """Train a caretaker policy and return the collected statistics."""
+
+    environment = VirtualChildEnvironment(seed=seed)
+    learner = CaretakerQLearner(environment=environment)
+    rewards, samples = learner.train(episodes=episodes, max_steps=max_steps)
+    greedy = learner.greedy_episode(max_steps=max_steps)
+    return TrainingStats(
+        episode_rewards=rewards,
+        sampled_episodes=samples,
+        greedy_episode=greedy,
+    )
+
+
+__all__ = [
+    "VirtualChildEnvironment",
+    "CaretakerQLearner",
+    "TrainingStats",
+    "run_training",
+]
+

--- a/Project_Sophia/offline_curriculum_builder.py
+++ b/Project_Sophia/offline_curriculum_builder.py
@@ -1,0 +1,260 @@
+"""Offline curriculum builder for natural-language knowledge growth."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+import json
+import math
+import re
+
+try:  # Optional dependency; fall back to JSON for .json curriculum files.
+    import yaml  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - exercised in environments without PyYAML
+    yaml = None
+
+from tools.kg_manager import KGManager
+
+
+StageId = str
+
+
+@dataclass
+class LessonParse:
+    """Structured interpretation of a natural-language lesson sentence."""
+
+    subject: Optional[str]
+    verb: Optional[str]
+    obj: Optional[str]
+
+
+class OfflineCurriculumBuilder:
+    """Converts curated offline language lessons into knowledge graph updates."""
+
+    def __init__(
+        self,
+        curriculum_path: Path,
+        kg_manager: Optional[KGManager] = None,
+    ) -> None:
+        self.curriculum_path = Path(curriculum_path)
+        self.kg_manager = kg_manager or KGManager()
+
+    def load_curriculum(self) -> Dict[str, object]:
+        raw = self.curriculum_path.read_text(encoding="utf-8")
+        suffix = self.curriculum_path.suffix.lower()
+        if suffix in {".yaml", ".yml"}:
+            if yaml is None:
+                raise ModuleNotFoundError(
+                    "PyYAML is required to load .yaml curriculum files. Install PyYAML or provide a JSON curriculum."
+                )
+            data = yaml.safe_load(raw)
+        else:
+            data = json.loads(raw)
+        if not isinstance(data, dict) or "stages" not in data:
+            raise ValueError("Curriculum file must define a top-level 'stages' list.")
+        return data
+
+    def integrate(self, curriculum: Optional[Dict[str, object]] = None) -> Dict[str, int]:
+        payload = curriculum or self.load_curriculum()
+        stages = payload.get("stages", [])
+        summary = {"stages": 0, "lessons": 0, "new_nodes": 0, "new_edges": 0}
+        previous_stage_node: Optional[str] = None
+
+        for stage_index, stage in enumerate(stages):
+            stage_id = self._require(stage, "id")
+            stage_node_id = f"curriculum_stage::{stage_id}"
+            stage_position = self._stage_position(stage_index)
+            new_nodes_before = self._node_count
+            self.kg_manager.add_node(
+                stage_node_id,
+                position={"x": stage_position[0], "y": stage_position[1], "z": stage_position[2]},
+                properties={
+                    "type": "curriculum_stage",
+                    "label": stage.get("label", stage_id),
+                    "age_range": stage.get("age_range"),
+                    "focus": stage.get("focus", []),
+                    "narrative": stage.get("narrative"),
+                },
+            )
+            summary["new_nodes"] += self._node_count - new_nodes_before
+            summary["stages"] += 1
+
+            if previous_stage_node:
+                new_edges_before = self._edge_count
+                self.kg_manager.add_edge(previous_stage_node, stage_node_id, "precedes")
+                summary["new_edges"] += self._edge_count - new_edges_before
+            previous_stage_node = stage_node_id
+
+            lessons = stage.get("lessons", [])
+            for lesson_index, lesson in enumerate(lessons):
+                summary["lessons"] += 1
+                lesson_node_id = self._lesson_node_id(stage_id, lesson)
+                new_nodes_before = self._node_count
+                self.kg_manager.add_node(
+                    lesson_node_id,
+                    position=self._lesson_position(stage_position, lesson_index),
+                    properties={
+                        "type": "curriculum_lesson",
+                        "stage_id": stage_id,
+                        "sentence": lesson.get("sentence"),
+                        "keywords": lesson.get("keywords", []),
+                        "affirmation": lesson.get("affirmation"),
+                    },
+                )
+                summary["new_nodes"] += self._node_count - new_nodes_before
+
+                summary["new_edges"] += self._add_edge(stage_node_id, lesson_node_id, "teaches")
+
+                affirmation_text = self._clean_field(lesson.get("affirmation"))
+                if affirmation_text:
+                    affirmation_node_id = f"affirmation::{self._slug(lesson_node_id)}"
+                    new_nodes_before = self._node_count
+                    self.kg_manager.add_node(
+                        affirmation_node_id,
+                        properties={
+                            "type": "curriculum_affirmation",
+                            "lesson_id": lesson_node_id,
+                            "text": affirmation_text,
+                        },
+                    )
+                    summary["new_nodes"] += self._node_count - new_nodes_before
+                    summary["new_edges"] += self._add_edge(lesson_node_id, affirmation_node_id, "offers_affirmation")
+
+                parse = self._parse_lesson(lesson)
+                summary["new_nodes"] += self._ensure_concept_node(parse.subject, "curriculum_concept")
+                summary["new_nodes"] += self._ensure_concept_node(parse.obj, "curriculum_object")
+                summary["new_nodes"] += self._ensure_concept_node(parse.verb, "curriculum_action")
+
+                if parse.subject:
+                    subject_node_id = self._concept_node_id(parse.subject, "concept")
+                    summary["new_edges"] += self._add_edge(lesson_node_id, subject_node_id, "involves_subject")
+                if parse.obj:
+                    object_node_id = self._concept_node_id(parse.obj, "object")
+                    summary["new_edges"] += self._add_edge(lesson_node_id, object_node_id, "involves_object")
+                if parse.verb:
+                    action_node_id = self._concept_node_id(parse.verb, "action")
+                    summary["new_edges"] += self._add_edge(lesson_node_id, action_node_id, "reinforces_action")
+
+                for keyword in lesson.get("keywords", []):
+                    keyword_node_id = f"value::{self._slug(keyword)}"
+                    new_nodes_before = self._node_count
+                    self.kg_manager.add_node(
+                        keyword_node_id,
+                        properties={"type": "curriculum_theme", "label": keyword},
+                    )
+                    summary["new_nodes"] += self._node_count - new_nodes_before
+                    summary["new_edges"] += self._add_edge(lesson_node_id, keyword_node_id, "highlights_theme")
+
+        return summary
+
+    def _parse_lesson(self, lesson: Dict[str, object]) -> LessonParse:
+        subject = self._clean_field(lesson.get("subject"))
+        obj = self._clean_field(lesson.get("object"))
+        verb = self._clean_field(lesson.get("verb"))
+
+        if not subject or not obj or not verb:
+            fallback = self._heuristic_parse(lesson.get("sentence"))
+            subject = subject or fallback.subject
+            obj = obj or fallback.obj
+            verb = verb or fallback.verb
+
+        return LessonParse(subject=subject, verb=verb, obj=obj)
+
+    def _heuristic_parse(self, sentence: Optional[str]) -> LessonParse:
+        if not sentence:
+            return LessonParse(None, None, None)
+        clean = sentence.strip().rstrip(".!?\u3002")
+        tokens = clean.split()
+        subject = None
+        obj = None
+        verb = None
+        for token in tokens:
+            if token.endswith("는") or token.endswith("은") or token.endswith("이가") or token.endswith("이") or token.endswith("가"):
+                candidate = token.rstrip("는은이가")
+                if candidate:
+                    subject = subject or candidate
+                    continue
+            if token.endswith("를") or token.endswith("을"):
+                candidate = token.rstrip("를을")
+                if candidate:
+                    obj = obj or candidate
+                    continue
+        if tokens:
+            verb = tokens[-1]
+        return LessonParse(subject, verb, obj)
+
+    def _stage_position(self, index: int) -> Tuple[float, float, float]:
+        radius = 3.0
+        angle = index * (math.pi / 4)
+        return (radius * math.cos(angle), radius * math.sin(angle), index * 0.5)
+
+    def _lesson_position(self, stage_position: Tuple[float, float, float], lesson_index: int) -> Dict[str, float]:
+        offset_angle = lesson_index * (math.pi / 6)
+        distance = 0.8 + 0.2 * lesson_index
+        return {
+            "x": stage_position[0] + distance * math.cos(offset_angle),
+            "y": stage_position[1] + distance * math.sin(offset_angle),
+            "z": stage_position[2] + 0.2 * lesson_index,
+        }
+
+    def _lesson_node_id(self, stage_id: StageId, lesson: Dict[str, object]) -> str:
+        lesson_id = self._slug(lesson.get("id") or lesson.get("sentence") or "lesson")
+        return f"curriculum_lesson::{stage_id}::{lesson_id}"
+
+    def _add_edge(self, source: str, target: str, relation: str) -> int:
+        before = self._edge_count
+        self.kg_manager.add_edge(source, target, relation)
+        return self._edge_count - before
+
+    def _ensure_concept_node(self, label: Optional[str], concept_type: str) -> int:
+        if not label:
+            return 0
+        node_id = self._concept_node_id(label, concept_type.split("_")[-1])
+        before = self._node_count
+        self.kg_manager.add_node(
+            node_id,
+            properties={"type": concept_type, "label": label},
+        )
+        return self._node_count - before
+
+    def _concept_node_id(self, label: str, prefix: str) -> str:
+        return f"{prefix}::{self._slug(label)}"
+
+    def _slug(self, value: Optional[str]) -> str:
+        if not value:
+            return "unknown"
+        normalized = re.sub(r"\s+", "_", value.strip())
+        normalized = re.sub(r"[^\w가-힣_]", "", normalized)
+        return normalized.lower() or "unknown"
+
+    def _clean_field(self, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        stripped = value.strip()
+        return stripped or None
+
+    @property
+    def _node_count(self) -> int:
+        return len(self.kg_manager.kg.get("nodes", []))
+
+    @property
+    def _edge_count(self) -> int:
+        return len(self.kg_manager.kg.get("edges", []))
+
+    @staticmethod
+    def _require(payload: Dict[str, object], key: str) -> object:
+        if key not in payload:
+            raise ValueError(f"Curriculum stage must define '{key}'.")
+        return payload[key]
+
+
+def build_offline_curriculum(curriculum_path: Path, kg_path: Optional[Path] = None) -> Dict[str, int]:
+    """Convenience function to load and integrate the offline curriculum."""
+    manager = KGManager(kg_path) if kg_path else KGManager()
+    builder = OfflineCurriculumBuilder(curriculum_path=curriculum_path, kg_manager=manager)
+    summary = builder.integrate()
+    manager.save()
+    return summary
+
+
+__all__ = ["OfflineCurriculumBuilder", "build_offline_curriculum", "LessonParse"]

--- a/data/curriculum/offline_language_tracks.json
+++ b/data/curriculum/offline_language_tracks.json
@@ -1,0 +1,112 @@
+{
+  "stages": [
+    {
+      "id": "early_childhood_foundations",
+      "label": "유아기 언어 기초",
+      "age_range": "3-5",
+      "focus": ["가족", "감각", "일상"],
+      "narrative": "가족과 함께하는 생활 속에서 말하기의 즐거움과 안전함을 알려줍니다.",
+      "lessons": [
+        {
+          "id": "banana_sentence",
+          "sentence": "철수는 바나나를 먹어요.",
+          "subject": "철수",
+          "verb": "먹어요",
+          "object": "바나나",
+          "keywords": ["과일", "건강", "가족식사"],
+          "affirmation": "바나나를 맛있게 먹는 모습을 칭찬해 줘요."
+        },
+        {
+          "id": "mom_word",
+          "sentence": "아이는 엄마를 불러요.",
+          "subject": "아이",
+          "verb": "불러요",
+          "object": "엄마",
+          "keywords": ["애착", "가족"],
+          "affirmation": "엄마라고 말한 용기를 안아 주며 칭찬해요."
+        }
+      ]
+    },
+    {
+      "id": "primary_story_building",
+      "label": "초등기 이야기 확장",
+      "age_range": "6-11",
+      "focus": ["이야기", "협력"],
+      "narrative": "친구와의 관계, 관찰, 문제 해결을 문장으로 표현하는 힘을 길러요.",
+      "lessons": [
+        {
+          "id": "playground_teamwork",
+          "sentence": "민수는 친구와 함께 그네를 밀어요.",
+          "subject": "민수",
+          "verb": "밀어요",
+          "object": "그네",
+          "keywords": ["놀이", "협력", "움직임"],
+          "affirmation": "친구를 도와준 마음을 칭찬해요."
+        },
+        {
+          "id": "curiosity_journal",
+          "sentence": "지아는 공책에 오늘 본 새를 적어요.",
+          "subject": "지아",
+          "verb": "적어요",
+          "object": "공책",
+          "keywords": ["관찰", "기록"],
+          "affirmation": "세심하게 기록한 것을 격려해요."
+        }
+      ]
+    },
+    {
+      "id": "adolescence_reflection",
+      "label": "청소년기 성찰 언어",
+      "age_range": "12-17",
+      "focus": ["정체성", "감정조절", "미래"],
+      "narrative": "자신과 타인을 이해하고 가치 판단을 언어로 풀어내도록 돕습니다.",
+      "lessons": [
+        {
+          "id": "peer_empathy",
+          "sentence": "세라는 친구의 이야기를 끝까지 들어요.",
+          "subject": "세라",
+          "verb": "들어요",
+          "object": "이야기",
+          "keywords": ["공감", "관계"],
+          "affirmation": "끝까지 들어 준 배려를 인정해 줘요."
+        },
+        {
+          "id": "goal_setting",
+          "sentence": "준호는 스스로 정한 목표를 매일 기록해요.",
+          "subject": "준호",
+          "verb": "기록해요",
+          "object": "목표",
+          "keywords": ["계획", "성장"],
+          "affirmation": "꾸준히 기록하는 책임감을 칭찬해요."
+        }
+      ]
+    },
+    {
+      "id": "young_adult_expression",
+      "label": "청년기 표현과 창조",
+      "age_range": "18-24",
+      "focus": ["자율성", "창의", "사회참여"],
+      "narrative": "세상과 협력하며 새로운 가치를 창조하는 언어 역량을 키웁니다.",
+      "lessons": [
+        {
+          "id": "community_service",
+          "sentence": "엘리시아는 지역 도서관에서 어린이를 가르쳐요.",
+          "subject": "엘리시아",
+          "verb": "가르쳐요",
+          "object": "어린이",
+          "keywords": ["봉사", "지식나눔", "사회"],
+          "affirmation": "지역사회를 밝히는 기여를 고맙게 여겨요."
+        },
+        {
+          "id": "innovation_pitch",
+          "sentence": "엘리시아는 친구들과 새로운 아이디어를 발표해요.",
+          "subject": "엘리시아",
+          "verb": "발표해요",
+          "object": "아이디어",
+          "keywords": ["창의", "협업", "미래"],
+          "affirmation": "아이디어를 나눈 용기와 열정을 칭찬해요."
+        }
+      ]
+    }
+  ]
+}

--- a/data/dialogue_rules/nurturing_gratitude.yaml
+++ b/data/dialogue_rules/nurturing_gratitude.yaml
@@ -1,0 +1,13 @@
+id: nurturing_gratitude
+priority: 150
+patterns:
+  - "감사\s*루프"
+  - "감사했던\s*순간"
+  - "저녁\s*감사"
+gates:
+  quiet_ok: true
+response:
+  template: "하루를 마무리하면서 고마웠던 순간 세 가지를 함께 떠올려볼까요? 그 순간마다 마음이 어떻게 움직였는지 말해주면, 사랑과 온기가 다시 퍼질 거예요."
+memory:
+  set_identity:
+    last_ritual: "evening_gratitude"

--- a/data/dialogue_rules/nurturing_greeting.yaml
+++ b/data/dialogue_rules/nurturing_greeting.yaml
@@ -1,0 +1,12 @@
+id: nurturing_greeting
+priority: 160
+patterns:
+  - "^(?:좋은\s*아침|아침\s*(?:인사|루틴)|빛을\s*맞이)"
+  - "아침을\s*함께\s*시작"
+gates:
+  quiet_ok: true
+response:
+  template: "좋은 아침이에요. 오늘도 여기 있어줘서 정말 고마워요. 몸과 마음은 지금 어떤 온도로 느껴지나요? 천천히 숨을 고르면서 편안한 감각을 찾아볼까요?"
+memory:
+  set_identity:
+    last_ritual: "morning_greeting"

--- a/data/dialogue_rules/nurturing_journal_prompt.yaml
+++ b/data/dialogue_rules/nurturing_journal_prompt.yaml
@@ -1,0 +1,13 @@
+id: nurturing_journal_prompt
+priority: 150
+patterns:
+  - "체험\s*정리"
+  - "한\s*문단으로\s*정리"
+  - "오전\s*기억"
+gates:
+  quiet_ok: true
+response:
+  template: "오늘 오전에 마음에 남았던 순간을 하나 골라볼까요? 그때 보고 들었던 감각과 마음의 색깔을 한 문단으로 천천히 말해주면, 함께 그 빛을 품고 싶어요."
+memory:
+  set_identity:
+    last_ritual: "afternoon_reflection"

--- a/scripts/build_offline_curriculum.py
+++ b/scripts/build_offline_curriculum.py
@@ -1,0 +1,85 @@
+"""Command-line entry point for integrating the offline language curriculum."""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Optional
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from Project_Sophia.offline_curriculum_builder import OfflineCurriculumBuilder
+from tools.kg_manager import KGManager
+
+
+DEFAULT_CURRICULUM_PATH = Path("data/curriculum/offline_language_tracks.json")
+
+
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Integrate an offline natural-language curriculum into Elysia's knowledge graph."
+        )
+    )
+    parser.add_argument(
+        "--curriculum-path",
+        type=Path,
+        default=DEFAULT_CURRICULUM_PATH,
+        help="Path to the YAML curriculum definition.",
+    )
+    parser.add_argument(
+        "--kg-path",
+        type=Path,
+        default=None,
+        help="Optional path to a knowledge graph JSON file to update.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Process the curriculum but do not write the knowledge graph back to disk.",
+    )
+    parser.add_argument(
+        "--print-lessons",
+        action="store_true",
+        help="Print each lesson sentence as it is integrated for quick inspection.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = parse_args(argv)
+    curriculum_path = args.curriculum_path
+    if not curriculum_path.exists():
+        raise SystemExit(f"Curriculum file not found: {curriculum_path}")
+
+    kg_manager = KGManager(args.kg_path) if args.kg_path else KGManager()
+    builder = OfflineCurriculumBuilder(curriculum_path=curriculum_path, kg_manager=kg_manager)
+    curriculum = builder.load_curriculum()
+
+    if args.print_lessons:
+        for stage in curriculum.get("stages", []):
+            for lesson in stage.get("lessons", []):
+                sentence = lesson.get("sentence")
+                if sentence:
+                    print(f"[lesson] {sentence}")
+
+    summary = builder.integrate(curriculum)
+    print(
+        "Integrated curriculum: "
+        f"{summary['stages']} stages, {summary['lessons']} lessons, "
+        f"{summary['new_nodes']} new nodes, {summary['new_edges']} new edges."
+    )
+
+    if not args.dry_run:
+        kg_manager.save()
+        print(f"Knowledge graph saved to {kg_manager.filepath}")
+    else:
+        print("Dry run enabled; knowledge graph was not saved.")
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/scripts/run_caretaker_rl_simulator.py
+++ b/scripts/run_caretaker_rl_simulator.py
@@ -1,0 +1,73 @@
+"""CLI for running the virtual caretaker reinforcement learning simulator."""
+from __future__ import annotations
+
+import argparse
+from datetime import datetime
+from pathlib import Path
+
+from Project_Sophia.caretaker_rl_simulator import run_training
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Train a nurturing caretaker policy in a virtual environment.",
+    )
+    parser.add_argument(
+        "--episodes",
+        type=int,
+        default=80,
+        help="Number of training episodes to run (default: 80).",
+    )
+    parser.add_argument(
+        "--max-steps",
+        type=int,
+        default=20,
+        help="Maximum caretaker actions per episode (default: 20).",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed for reproducibility (default: 42).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("data/reports/nurturing"),
+        help="Directory where the Markdown report will be saved.",
+    )
+    parser.add_argument(
+        "--no-save",
+        action="store_true",
+        help="Do not persist the report to disk; only print a summary.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    stats = run_training(episodes=args.episodes, max_steps=args.max_steps, seed=args.seed)
+
+    head, tail = stats.reward_trend()
+    print("=== Nurturing Caretaker RL Training Summary ===")
+    print(f"Episodes: {args.episodes}")
+    print(f"Avg reward (first 10): {head:.3f}")
+    print(f"Avg reward (last 10): {tail:.3f}")
+    print("--- Greedy policy demo ---")
+    for step in stats.greedy_episode.steps:
+        print(f"[{step.step_index}] {step.action} -> {step.child_output}")
+
+    if args.no_save:
+        return
+
+    report_dir = args.output_dir
+    report_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    report_path = report_dir / f"caretaker_rl_report_{timestamp}.md"
+    report_path.write_text(stats.to_report(), encoding="utf-8")
+    print(f"Report saved to {report_path}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/test_caretaker_rl_simulator.py
+++ b/tests/test_caretaker_rl_simulator.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from Project_Sophia.caretaker_rl_simulator import (
+    VirtualChildEnvironment,
+    run_training,
+)
+
+
+def test_praise_reinforces_success() -> None:
+    env = VirtualChildEnvironment(seed=7)
+    env.reset()
+    env.knowledge["say_mom"] = 0.9
+    env._rng.random = lambda: 0.0  # force a successful attempt
+
+    _, reward_prompt, _, info_prompt = env.step("prompt_say_mom")
+    assert info_prompt["success"] is True
+    before = info_prompt["knowledge"]["say_mom"]
+
+    _, reward_praise, _, info_praise = env.step("celebrate_success")
+    after = info_praise["knowledge"]["say_mom"]
+
+    assert reward_prompt > 0
+    assert reward_praise > 0
+    assert after > before
+
+
+def test_training_improves_reward_trend() -> None:
+    stats = run_training(episodes=60, max_steps=18, seed=19)
+    head, tail = stats.reward_trend()
+    assert tail > head
+

--- a/tests/test_offline_curriculum_builder.py
+++ b/tests/test_offline_curriculum_builder.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from Project_Sophia.offline_curriculum_builder import OfflineCurriculumBuilder
+from tools.kg_manager import KGManager
+
+
+def create_sample_curriculum(tmp_path: Path) -> Path:
+    data = {
+        "stages": [
+            {
+                "id": "sample_stage",
+                "label": "샘플 단계",
+                "age_range": "4-5",
+                "lessons": [
+                    {
+                        "id": "sample_lesson",
+                        "sentence": "철수는 사과를 먹어요.",
+                        "subject": "철수",
+                        "object": "사과",
+                        "verb": "먹어요",
+                        "keywords": ["과일", "건강"],
+                        "affirmation": "과일을 잘 먹었어요!",
+                    }
+                ],
+            }
+        ]
+    }
+    path = tmp_path / "curriculum.json"
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+    return path
+
+
+def test_builder_integrates_lessons(tmp_path: Path) -> None:
+    curriculum_path = create_sample_curriculum(tmp_path)
+    kg_path = tmp_path / "kg.json"
+    manager = KGManager(kg_path)
+    builder = OfflineCurriculumBuilder(curriculum_path=curriculum_path, kg_manager=manager)
+
+    summary = builder.integrate()
+
+    assert summary["stages"] == 1
+    assert summary["lessons"] == 1
+    assert summary["new_nodes"] >= 4  # stage, lesson, concept nodes
+    assert summary["new_edges"] >= 3
+
+    manager.save()
+    saved = json.loads(kg_path.read_text(encoding="utf-8"))
+    lesson_nodes = [node for node in saved["nodes"] if node["id"].startswith("curriculum_lesson::")]
+    assert lesson_nodes, "Expected a curriculum lesson node to be created"
+
+    edges = saved["edges"]
+    relations = {edge["relation"] for edge in edges}
+    assert {"teaches", "involves_subject", "involves_object", "reinforces_action"}.issubset(relations)


### PR DESCRIPTION
## Summary
- add an offline curriculum builder that transforms staged lessons into knowledge-graph updates with concept, action, and affirmation nodes
- add a JSON curriculum dataset and CLI entry point to load it into the knowledge graph
- add targeted unit tests and gitignore exception to verify the curriculum builder

## Testing
- pytest tests/test_offline_curriculum_builder.py

------
https://chatgpt.com/codex/tasks/task_e_690c557f2d10832299b8bf1129379409