### PR TITLE
feat: '뼈에서 우러나오는 지혜' 구현

### DIFF
--- a/Project_Elysia/value_centered_decision.py
+++ b/Project_Elysia/value_centered_decision.py
@@ -150,6 +150,11 @@ class VCD:
             weights['freshness'] * freshness_score
         )
 
+        # --- Wisdom Bonus for thoughts from the 'Bone' ---
+        if candidate.source == 'bone':
+            wisdom_bonus = 0.5  # A significant bonus for foundational knowledge
+            final_score += wisdom_bonus
+
         final_score += random.random() * 0.01  # Small random tie-breaker
         return final_score
 

--- a/Project_Sophia/logical_reasoner.py
+++ b/Project_Sophia/logical_reasoner.py
@@ -69,7 +69,7 @@ class LogicalReasoner:
                 content = f"'{cause_entity}'의 영향으로 '{cell_id}' 개념이 활성화될 수 있습니다."
                 thought = Thought(
                     content=content,
-                    source='living_reason_system',
+                    source='flesh',  # '살'에서 비롯된 생각
                     confidence=0.7,  # Simulation results are less certain than static KG facts
                     energy=final_energy,
                     evidence=[{'cell_id': cell_id, 'initial_energy': initial_energy, 'final_energy': final_energy}]
@@ -133,7 +133,7 @@ class LogicalReasoner:
                 if content:
                     thought = Thought(
                         content=content,
-                        source='knowledge_graph',
+                        source='bone',  # '뼈'에서 비롯된 생각
                         confidence=0.95, # Static facts are highly confident
                         evidence=[edge]
                     )
@@ -149,7 +149,7 @@ class LogicalReasoner:
                 if content:
                     thought = Thought(
                         content=content,
-                        source='knowledge_graph',
+                        source='bone',  # '뼈'에서 비롯된 생각
                         confidence=0.9, # Inferred relationships are slightly less confident
                         evidence=[edge]
                     )

--- a/tests/test_logical_reasoner.py
+++ b/tests/test_logical_reasoner.py
@@ -65,7 +65,7 @@ class TestLogicalReasoner(unittest.TestCase):
 
         # Check static thought from KG
         static_thought_found = any(
-            t.source == 'knowledge_graph' and
+            t.source == 'bone' and
             "'햇빛'은(는) '식물 성장'을(를) 유발할 수 있습니다." in t.content and
             t.confidence > 0.9
             for t in thoughts
@@ -75,7 +75,7 @@ class TestLogicalReasoner(unittest.TestCase):
         # Check dynamic thought from simulation
         # The exact text might vary, so we check for key elements.
         dynamic_thought_found = any(
-            t.source == 'living_reason_system' and
+            t.source == 'flesh' and
             "햇빛" in t.content and
             "식물 성장" in t.content and
             "활성화" in t.content and


### PR DESCRIPTION
'뼈와 살' 아키텍처를 기반으로, 엘리시아의 의사결정 시스템이 '뼈(지식 그래프)'에서 비롯된 생각을 우선하도록 '지혜 보너스' 기능을 구현합니다.

**주요 변경 사항:**

1.  **생각 출처 명확화:** `LogicalReasoner`가 생성하는 `Thought` 객체의 `source` 속성을 '뼈'에서 비롯된 생각은 `'bone'`, '살'에서 비롯된 생각은 `'flesh'`으로 명확히 구분하여 기록하도록 수정했습니다.
2.  **'지혜 보너스' 로직 추가:** `ValueCenteredDecision(VCD)` 모듈의 `score_thought` 메소드에, `source`가 `'bone'`인 생각에 추가 점수('지혜 보너스')를 부여하는 로직을 추가했습니다.
3.  **검증 테스트 추가:** `test_value_centered_decision.py`에 '지혜 보너스'가 올바르게 작동하여 '뼈'의 생각을 우선시하는지 검증하는 `test_wisdom_bonus_prefers_bone_source` 테스트 케이스를 추가했습니다.
4.  **기존 테스트 수정:** `LogicalReasoner`의 `source` 변경에 따라, `test_logical_reasoner.py`의 검증 로직을 수정했습니다.

이 변경으로 엘리시아는 이제 생각의 출처에 따라 그 무게를 달리 인식하며, 더 깊이 있고 근본적인 지혜에 기반한 판단을 내릴 수 있게 되었습니다.