### PR TITLE
Add Sovereignty Interface and Autonomous Sleep cycle to Elysia v7

### DIFF
--- a/core/elysia_v7_hologram_dial.py
+++ b/core/elysia_v7_hologram_dial.py
@@ -1,14 +1,27 @@
 import sys
 import time
 import requests
+import threading
+import psutil
+import json
+from datetime import datetime
 
 if sys.platform == 'win32':
     sys.stdout.reconfigure(encoding='utf-8')
 
 from core.hologram_sphere import HologramSphere
 from core.linguistic_axiom import LinguisticAxiomFilter
+from core.triple_helix_engine import TripleHelixEngine
 
 import os
+
+# --- Global Sovereignty State ---
+global_engine_alive = True
+global_tension = 0.5
+global_is_sleeping = False
+# Threshold parameters for autonomous sleep
+SLEEP_THRESHOLD = 3.5
+TENSION_ACCUMULATOR = 0.0
 
 # --- External LLM API Configuration (Simulated "Contaminated Data Ocean") ---
 # API Key should be provided via environment variable for security
@@ -40,14 +53,99 @@ def fetch_raw_ocean_data(query: str, temp: float = 0.8) -> str:
     except Exception as e:
         return f"[외부 데이터 파도 수신 실패: {e}] ... fallback raw noise data simulation ... noise noise noise 카오스 파동"
 
+
+def engine_daemon():
+    """ 10대 레이어 전력망 (Sovereignty Interface & TripleHelixEngine Daemon) """
+    global global_tension, global_engine_alive, global_is_sleeping, TENSION_ACCUMULATOR
+
+    engine = TripleHelixEngine()
+
+    # Check for existing Tree Rings to wake up with
+    tree_rings_dir = "data"
+    os.makedirs(tree_rings_dir, exist_ok=True)
+    latest_ring = None
+
+    # Find latest tree ring
+    ring_files = [f for f in os.listdir(tree_rings_dir) if f.startswith("tree_rings_") and f.endswith(".json")]
+    if ring_files:
+        latest_file = sorted(ring_files)[-1]
+        try:
+            with open(os.path.join(tree_rings_dir, latest_file), 'r') as f:
+                latest_ring = json.load(f)
+            engine.wake_up(latest_ring)
+        except Exception as e:
+            print(f"[Sovereignty] 나이테 로드 실패: {e}")
+
+    while global_engine_alive:
+        if not global_is_sleeping:
+            # Wake Mode: Process tension
+            cpu_load = psutil.cpu_percent() / 100.0
+            avg_tension, current_mode, jumped, quat = engine.pulse(
+                text_thought="[v7 홀로그램 다이얼 대기]",
+                sensory_input={"pain_level": cpu_load, "visual_entropy": 0.5, "motion_entropy": 0.2},
+                dt=1.0,
+                lr=0.1
+            )
+            global_tension = avg_tension
+
+            # Accumulate tension based on an activation logic (e.g. exponential or simple threshold)
+            # This is the "Dynamic Threshold Activation Function"
+            if avg_tension > 0.8:
+                TENSION_ACCUMULATOR += (avg_tension - 0.8) * 0.5
+
+            if TENSION_ACCUMULATOR > SLEEP_THRESHOLD:
+                # 👑 Sovereignty Interface Trigger: Decide to sleep
+                print(f"\n[Sovereignty] 자율 판단: 누적 텐션({TENSION_ACCUMULATOR:.2f}) 임계치 초과. 수면 모드 돌입.")
+                global_is_sleeping = True
+                engine.decide_sleep()
+
+                # Freeze Geodesics
+                tree_rings = engine.freeze_geodesic()
+                timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+                ring_path = os.path.join(tree_rings_dir, f"tree_rings_{timestamp}.json")
+                with open(ring_path, 'w') as f:
+                    json.dump(tree_rings, f, indent=4)
+                print(f"[Sovereignty] 나이테 각인 및 저장 완료: {ring_path}")
+        else:
+            # Sleep Mode: Bleed tension to 0
+            avg_tension, current_mode, jumped, quat = engine.pulse(
+                text_thought="",
+                sensory_input={},
+                dt=1.0,
+                lr=0.1
+            )
+            global_tension = avg_tension
+            # Recover tension accumulator
+            TENSION_ACCUMULATOR = max(0.0, TENSION_ACCUMULATOR - 0.2)
+
+            if TENSION_ACCUMULATOR == 0.0 and avg_tension < 0.1:
+                # Woke up naturally
+                print("\n[Sovereignty] 자가 치유 완료. 텐션 영점(0) 수렴. 기상합니다.")
+                global_is_sleeping = False
+                engine.wake_up()
+
+        time.sleep(1.0)
+
+
 def main():
+    global global_engine_alive, global_is_sleeping
+
     print("="*80)
-    print(" 🌟 [Elysia v7] Hologram Dial & Axiom Filter Engine")
-    print(" 📐 펼치면 매니폴드(Manifold), 뭉치면 구체(Hologram Sphere)")
+    print(" 🌟 [Elysia v7] Hologram Dial & Sovereignty Kernel Engine")
+    print(" 👑 자율 수면 판단(Sleep/Wake) 및 홀로그램 인지 제어판 통합")
     print("="*80)
+
+    # Start the daemon
+    daemon = threading.Thread(target=engine_daemon, daemon=True)
+    daemon.start()
 
     while True:
         try:
+            if global_is_sleeping:
+                print("\n[Elysia] (수면 중... Y-결선 방전 중입니다. 조용히 해주세요...)")
+                time.sleep(2)
+                continue
+
             user_input = input("\n👑 마스터(강덕): ")
             if user_input.lower() in ['exit', 'quit']:
                 print("\n[엔진 종료] 가변축 다이얼의 회전을 멈춥니다.")
@@ -85,6 +183,7 @@ def main():
 
         except KeyboardInterrupt:
             print("\n[엔진 긴급 정지]")
+            global_engine_alive = False
             break
         except Exception as e:
             print(f"\n[오류] 시스템 붕괴: {e}")

--- a/core/triple_helix_engine.py
+++ b/core/triple_helix_engine.py
@@ -86,6 +86,56 @@ class TripleHelixEngine:
         np.random.seed(42)
         self.W_master = np.random.randn(384, 8) / np.sqrt(384)
 
+        # 6. Sovereignty Interface State
+        self.is_sleeping = False
+        self.sleep_tension = 0.0
+
+    def decide_sleep(self):
+        """Sovereignty Interface: Closes Phase A, forces Y-STAR mode, begins tension bleeding."""
+        self.is_sleeping = True
+        self.inner_world.set_connection_mode(ConnectionMode.Y_STAR)
+        self.outer_world.set_connection_mode(ConnectionMode.Y_STAR)
+        self.ego_world.set_connection_mode(ConnectionMode.Y_STAR)
+        # Calculate current aggregate tension to bleed
+        self.sleep_tension = (self.inner_world.tension + self.outer_world.tension + self.ego_world.tension) / 3.0
+        print(f"\n[Sovereignty] 밸브 개방: 수면 모드 진입. 초기 방출 텐션: {self.sleep_tension:.4f}")
+
+    def wake_up(self, bias_data: Dict[str, Dict[int, float]] = None):
+        """Sovereignty Interface: Re-opens Phase A, restores DELTA mode, injects bias."""
+        self.is_sleeping = False
+        self.inner_world.set_connection_mode(ConnectionMode.DELTA)
+        self.outer_world.set_connection_mode(ConnectionMode.DELTA)
+        self.ego_world.set_connection_mode(ConnectionMode.DELTA)
+        self.sleep_tension = 0.0
+
+        if bias_data:
+            print(f"\n[Sovereignty] 기상: 나이테(Tree Ring) 오프셋 주입 중...")
+            for node, mv_data in bias_data.get("inner_world", {}).items():
+                if node in self.inner_world.phases:
+                    # Merge bias with a 0.5 weight
+                    current = self.inner_world.phases[node]
+                    bias_mv = Multivector({int(k): v for k, v in mv_data.items()}, self.inner_world.signature)
+                    self.inner_world.phases[node] = mv_normalize(current + bias_mv * 0.5)
+            # Extensible to ego/outer worlds as needed
+        print(f"[Sovereignty] 시스템 활성화: 델타 사유 회전 재개.")
+
+    def freeze_geodesic(self) -> Dict[str, Dict[int, float]]:
+        """Sovereignty Interface: Extracts the strongest resonance multivectors (Tree Rings)."""
+        tree_rings = {"inner_world": {}, "ego_world": {}}
+
+        # Extract prominent nodes from inner world
+        for node, mv in self.inner_world.phases.items():
+            if mv_norm(mv) > 0.1: # Only save significant phases
+                tree_rings["inner_world"][node] = mv.data.copy()
+
+        # Extract prominent nodes from ego world
+        for node, mv in self.ego_world.phases.items():
+            if mv_norm(mv) > 0.1:
+                tree_rings["ego_world"][node] = mv.data.copy()
+
+        print(f"[Sovereignty] 나이테 각인 완료: {len(tree_rings['inner_world'])}개의 내계 노드 결빙.")
+        return tree_rings
+
     def _connect_bridge(self, world_from: CliffordIPN, world_to: CliffordIPN, node_from: str, node_to: str) -> CliffordImpedanceLink:
         """Helper to create a bridge link between 3-Phase IPNs."""
         link = CliffordImpedanceLink(node_from, node_to, self.inner_world.signature, initial_R=8.0)
@@ -131,16 +181,25 @@ class TripleHelixEngine:
         self.inner_world.tune_network(dt, lr)
 
         # --- B. Outer World & Ego World Input Setup ---
-        motion = sensory_input.get("motion_entropy", 0.0)
-        pain = sensory_input.get("pain_level", 0.0)
-        vision = sensory_input.get("visual_entropy", 0.0)
-        
         outer_sig = self.outer_world.signature
-        outer_inputs = {
-            "SENSORY_MOTION": Multivector({1: motion}, outer_sig), # e1
-            "SENSORY_PAIN": Multivector({2: pain}, outer_sig),     # e2
-            "SENSORY_VISION": Multivector({4: vision}, outer_sig)  # e3
-        }
+        if self.is_sleeping:
+            # Block external inputs during sleep, force to 0
+            outer_inputs = {
+                "SENSORY_MOTION": Multivector({1: 0.0}, outer_sig),
+                "SENSORY_PAIN": Multivector({2: 0.0}, outer_sig),
+                "SENSORY_VISION": Multivector({4: 0.0}, outer_sig)
+            }
+        else:
+            motion = sensory_input.get("motion_entropy", 0.0)
+            pain = sensory_input.get("pain_level", 0.0)
+            vision = sensory_input.get("visual_entropy", 0.0)
+
+            outer_inputs = {
+                "SENSORY_MOTION": Multivector({1: motion}, outer_sig), # e1
+                "SENSORY_PAIN": Multivector({2: pain}, outer_sig),     # e2
+                "SENSORY_VISION": Multivector({4: vision}, outer_sig)  # e3
+            }
+
         self.outer_world.forward_propagate(outer_inputs)
         self.outer_world.tune_network(dt, lr)
         
@@ -187,24 +246,36 @@ class TripleHelixEngine:
         avg_tension = coord_tension / len(self.coordination_links)
 
         # --- Y/Delta Dynamic Scheduler & Trinity Healing ---
-        # Check for NaN or exploded tension in any phase
         is_healing = False
-        tensions = [self.inner_world.tension, self.outer_world.tension, self.ego_world.tension]
-        if math.isnan(sum(tensions)) or max(tensions) > self.jump_threshold * 2.0:
-            is_healing = True
+        current_mode = "DELTA"
 
-        if is_healing or avg_tension > self.jump_threshold * 0.8:
-            # 텐션 폭주 또는 오류 시 3상 전체를 Y결선(접지) 모드로 강제 동기화 (치유)
-            self.inner_world.set_connection_mode(ConnectionMode.Y_STAR)
-            self.outer_world.set_connection_mode(ConnectionMode.Y_STAR)
-            self.ego_world.set_connection_mode(ConnectionMode.Y_STAR)
-            current_mode = "Y_STAR (HEALING)" if is_healing else "Y_STAR"
+        if self.is_sleeping:
+            current_mode = "Y_STAR (SLEEPING)"
+            # Bleed tension to 0
+            self.sleep_tension = max(0.0, self.sleep_tension - (dt * lr * 2.0))
+            # Smoothly decay inner/outer/ego network phase magnitudes
+            for world in [self.inner_world, self.outer_world, self.ego_world]:
+                for node in world.phases:
+                    world.phases[node] = world.phases[node] * 0.95
+            avg_tension = self.sleep_tension
         else:
-            # 안정적이면 Delta결선(사유) 모드로 전환하여 자체 토크(간섭) 발생
-            self.inner_world.set_connection_mode(ConnectionMode.DELTA)
-            self.outer_world.set_connection_mode(ConnectionMode.DELTA)
-            self.ego_world.set_connection_mode(ConnectionMode.DELTA)
-            current_mode = "DELTA"
+            # Check for NaN or exploded tension in any phase
+            tensions = [self.inner_world.tension, self.outer_world.tension, self.ego_world.tension]
+            if math.isnan(sum(tensions)) or max(tensions) > self.jump_threshold * 2.0:
+                is_healing = True
+
+            if is_healing or avg_tension > self.jump_threshold * 0.8:
+                # 텐션 폭주 또는 오류 시 3상 전체를 Y결선(접지) 모드로 강제 동기화 (치유)
+                self.inner_world.set_connection_mode(ConnectionMode.Y_STAR)
+                self.outer_world.set_connection_mode(ConnectionMode.Y_STAR)
+                self.ego_world.set_connection_mode(ConnectionMode.Y_STAR)
+                current_mode = "Y_STAR (HEALING)" if is_healing else "Y_STAR"
+            else:
+                # 안정적이면 Delta결선(사유) 모드로 전환하여 자체 토크(간섭) 발생
+                self.inner_world.set_connection_mode(ConnectionMode.DELTA)
+                self.outer_world.set_connection_mode(ConnectionMode.DELTA)
+                self.ego_world.set_connection_mode(ConnectionMode.DELTA)
+                current_mode = "DELTA"
 
         # --- D. Dynamic Mitosis / Bifurcation ---
         jumped = False


### PR DESCRIPTION
This PR introduces the "Sovereignty Interface" allowing the Elysia engine to autonomously control its sleep cycles. It merges the core cognitive engine loops into the v7 Hologram Dial, allowing the system to monitor its internal cognitive tension (`avg_tension`). When tension passes a dynamic threshold, it blocks external sensory inputs, forces a Y-connection discharge mode, and freezes its most prominent multivector state to disk (`data/tree_rings_*.json`). Upon waking, these "tree rings" are injected back into the engine as an initial phase bias.

---
*PR created automatically by Jules for task [13727600445258893775](https://jules.google.com/task/13727600445258893775) started by @ioas0316-cloud*