### PR TITLE
feat: Implement Sequential Phase Shift for text-to-phase mapping

### DIFF
--- a/core/brain/causal_phase_mapper.py
+++ b/core/brain/causal_phase_mapper.py
@@ -17,17 +17,23 @@ class CausalPhaseMapper:
     def text_to_phase(self, text):
         """단어의 기하학적 구조를 4D 홉프 토러스 직교 분리 파동으로 변환 (인과율 보존)"""
         if not text:
-            return torch.tensor([1.0, 0.0, 0.0, 0.0], dtype=torch.float32, device=self.device)
+            # 기본 궤적은 최소 1개의 텐서로 이루어짐
+            return torch.tensor([[1.0, 0.0, 0.0, 0.0]], dtype=torch.float32, device=self.device)
             
-        w_sum, x_sum, y_sum, z_sum = 0.0, 0.0, 0.0, 0.0
-        valid_chars = 0
+        trajectory = []
         
+        # 순서의 공간화(Sequential Phase Shift) 상수: 황금비 각도 (Golden Ratio Angle)
+        delta_theta = 2.39996
+
         # 상수 사전 길이 정의
         len_choseong = 19
         len_jungseong = 21
         len_jongseong = 28
 
-        for char in text:
+        for i, char in enumerate(text):
+            # 순서에 따른 누적 위상 시프트
+            seq_shift = i * delta_theta
+
             code = ord(char)
             if 0xAC00 <= code <= 0xD7A3:
                 base = code - 0xAC00
@@ -35,10 +41,10 @@ class CausalPhaseMapper:
                 jung = ((base - jong) // 28) % 21
                 cho = (((base - jong) // 28) - jung) // 21
                 
-                # 1. 중성(모음) 각도
-                theta_v = ((jung + 0.5) / len_jungseong) * 2 * math.pi - math.pi
-                # 2. 초성(자음) 각도
-                theta_c = ((cho + 0.5) / len_choseong) * 2 * math.pi - math.pi
+                # 1. 중성(모음) 각도 + 순차 위상 시프트
+                theta_v = ((jung + 0.5) / len_jungseong) * 2 * math.pi - math.pi + seq_shift
+                # 2. 초성(자음) 각도 + 순차 위상 시프트
+                theta_c = ((cho + 0.5) / len_choseong) * 2 * math.pi - math.pi + seq_shift
                 # 3. 종성(자음) 반지름 비 분배
                 r_ratio = 0.05 + 0.90 * (jong / (len_jongseong - 1))
                 theta_r = r_ratio * (math.pi / 2.0)
@@ -49,32 +55,28 @@ class CausalPhaseMapper:
                 y = math.sin(theta_r) * math.cos(theta_c)
                 z = math.sin(theta_r) * math.sin(theta_c)
                 
-                w_sum += w; x_sum += x; y_sum += y; z_sum += z
-                valid_chars += 1
             else:
                 val = (code % 256) / 128.0 - 1.0
-                # 비한글 특수 처리를 위한 기본 홉프 형태 유지
-                theta_v = val * math.pi
-                theta_c = val * math.pi
+                # 비한글 특수 처리를 위한 기본 홉프 형태 유지 + 순차 위상 시프트
+                theta_v = val * math.pi + seq_shift
+                theta_c = val * math.pi + seq_shift
                 theta_r = 0.5 * (math.pi / 2.0)
                 
-                w_sum += math.cos(theta_r) * math.cos(theta_v)
-                x_sum += math.cos(theta_r) * math.sin(theta_v)
-                y_sum += math.sin(theta_r) * math.cos(theta_c)
-                z_sum += math.sin(theta_r) * math.sin(theta_c)
-                valid_chars += 1
+                w = math.cos(theta_r) * math.cos(theta_v)
+                x = math.cos(theta_r) * math.sin(theta_v)
+                y = math.sin(theta_r) * math.cos(theta_c)
+                z = math.sin(theta_r) * math.sin(theta_c)
+
+            norm = (w**2 + x**2 + y**2 + z**2)**0.5
+            if norm > 0:
+                trajectory.append([w/norm, x/norm, y/norm, z/norm])
+            else:
+                trajectory.append([1.0, 0.0, 0.0, 0.0])
                 
-        if valid_chars > 0:
-            w_sum /= valid_chars
-            x_sum /= valid_chars
-            y_sum /= valid_chars
-            z_sum /= valid_chars
-            
-        norm = (w_sum**2 + x_sum**2 + y_sum**2 + z_sum**2)**0.5
-        if norm > 0:
-            return torch.tensor([w_sum/norm, x_sum/norm, y_sum/norm, z_sum/norm], 
-                              dtype=torch.float32, device=self.device)
-        return torch.tensor([1.0, 0.0, 0.0, 0.0], dtype=torch.float32, device=self.device)
+        if len(trajectory) > 0:
+            return torch.tensor(trajectory, dtype=torch.float32, device=self.device)
+
+        return torch.tensor([[1.0, 0.0, 0.0, 0.0]], dtype=torch.float32, device=self.device)
 
     def color_to_phase(self, r: int, g: int, b: int):
         """색상 RGB 값을 색조(Hue)와 채도(Sat) 주파수로 환산하여 4D 쿼터니언 위상으로 사영합니다."""

--- a/core/brain/elysia_knowledge_helix.py
+++ b/core/brain/elysia_knowledge_helix.py
@@ -1,0 +1,172 @@
+import torch
+import math
+from core.brain.causal_phase_mapper import CausalPhaseMapper
+
+class KnowledgeHelixMapper:
+    def __init__(self, device='cpu'):
+        self.device = device
+        self.causal_mapper = CausalPhaseMapper(device=device)
+        self.memory_bank = [] # Store tuple of (metadata, trajectory_tensor)
+
+        # 역사적 대주기 (한 바퀴 2pi) = 100년 (1세기)
+        self.century_period = 100.0
+
+    def year_to_phase(self, year: int):
+        """
+        역사의 은하계 (Temporal Galaxy)
+        기준축: '연도(Year)'.
+        선형적 타임라인을 원형 궤도의 고유 주파수로 변환합니다.
+        100년을 2pi(한 바퀴)로 매핑.
+        """
+        theta_year = (year % self.century_period) / self.century_period * 2 * math.pi - math.pi
+        century = year // 100
+        theta_century = (century * 0.1) % (2 * math.pi) - math.pi
+
+        theta_r = 0.5 * (math.pi / 2.0)
+
+        w = math.cos(theta_r) * math.cos(theta_year)
+        x = math.cos(theta_r) * math.sin(theta_year)
+        y = math.sin(theta_r) * math.cos(theta_century)
+        z = math.sin(theta_r) * math.sin(theta_century)
+
+        norm = (w**2 + x**2 + y**2 + z**2)**0.5
+        phase = torch.tensor([w/norm, x/norm, y/norm, z/norm], dtype=torch.float32, device=self.device)
+        return phase
+
+    def concept_to_helix(self, concept_text: str, level: int):
+        """
+        교과의 나선 토러스 (Spiral Curriculum Helix)
+        기준축: '학년/난이도(Academic Level)'.
+        개념의 기본 주파수는 유지하되, 레벨을 나선형 z축(반지름비/위상 오프셋)으로 확장.
+        """
+        base_trajectory = self.causal_mapper.text_to_phase(concept_text)
+
+        # 난이도가 높아질수록 나선의 수직 축(Z, 또는 4차원 반경각)이 변화
+        # 여기서는 레벨을 yz 평면의 반지름 각도(theta_r)의 미세 조정으로 매핑
+        helix_trajectory = []
+        for point in base_trajectory:
+            w, x, y, z = point.tolist()
+
+            # 원래 극좌표 복원 (근사)
+            # w = cos(r)cos(v), x = cos(r)sin(v)
+            # y = sin(r)cos(c), z = sin(r)sin(c)
+            r_val = math.atan2(math.sqrt(y**2 + z**2), math.sqrt(w**2 + x**2))
+
+            # 레벨에 따라 r_val (나선의 높이) 이동
+            new_r = r_val + (level * 0.05)
+
+            # 각도 보존 (공명 유지를 위해)
+            theta_v = math.atan2(x, w)
+            theta_c = math.atan2(z, y)
+
+            nw = math.cos(new_r) * math.cos(theta_v)
+            nx = math.cos(new_r) * math.sin(theta_v)
+            ny = math.sin(new_r) * math.cos(theta_c)
+            nz = math.sin(new_r) * math.sin(theta_c)
+
+            norm = (nw**2 + nx**2 + ny**2 + nz**2)**0.5
+            helix_trajectory.append([nw/norm, nx/norm, ny/norm, nz/norm])
+
+        return torch.tensor(helix_trajectory, dtype=torch.float32, device=self.device)
+
+    def anchor_knowledge(self, metadata, trajectory):
+        self.memory_bank.append({"meta": metadata, "phase": trajectory})
+
+    def retrieve_by_phase(self, query_phase: torch.Tensor, top_k=1, is_trajectory=False):
+        """
+        O(1) 위상 공명 (Phase Resonance) 기반 검색
+        """
+        results = []
+        for item in self.memory_bank:
+            target_phase = item["phase"]
+
+            if is_trajectory:
+                # 궤적 비교: 평균 공명도 측정
+                if target_phase.shape == query_phase.shape:
+                    dot_product = torch.sum(query_phase * target_phase, dim=1)
+                    resonance = torch.mean(dot_product).item()
+                else:
+                    resonance = 0.0
+            else:
+                # 단일 점 비교
+                if len(target_phase.shape) == 1:
+                    resonance = torch.dot(query_phase, target_phase).item()
+                else:
+                    # 대상이 궤적일 경우 궤적의 첫 점과 공명
+                    resonance = torch.dot(query_phase, target_phase[0]).item()
+
+            results.append((resonance, item["meta"]))
+
+        # O(1) 공명 시뮬레이션 (여기서는 리스트 정렬로 모사하지만, 실제 뉴럴 필드에서는 즉각 활성화됨)
+        results.sort(key=lambda x: x[0], reverse=True)
+        return results[:top_k]
+
+def run_benchmark():
+    print("=" * 60)
+    print("🚀 [Knowledge Helix] 초차원 지식 나선 매퍼 벤치마크")
+    print("=" * 60)
+
+    mapper = KnowledgeHelixMapper()
+
+    # 1. 역사의 은하계 매핑
+    print("[1] 역사(Temporal Axis) 지식 앵커링")
+    events = [
+        (1392, "조선 건국"),
+        (1443, "훈민정음 창제"),
+        (1592, "임진왜란"),
+        (1636, "병자호란")
+    ]
+    for year, desc in events:
+        phase = mapper.year_to_phase(year)
+        mapper.anchor_knowledge(f"역사: {year}년 - {desc}", phase)
+        print(f"  앵커 완료: {desc} (Year {year}) -> Phase Norm: {torch.norm(phase):.4f}")
+
+    # 특정 연도 공명 관측
+    query_year = 1592
+    query_phase = mapper.year_to_phase(query_year)
+    print(f"\n  🔍 관측 쿼리: {query_year}년 파동 방사")
+    results = mapper.retrieve_by_phase(query_phase, top_k=2, is_trajectory=False)
+    for res, meta in results:
+        print(f"    => 공명도 {res:.4f}: {meta}")
+
+    print("-" * 60)
+
+    # 2. 교과의 나선 토러스 매핑
+    print("[2] 교과(Spiral Axis) 지식 앵커링")
+    concepts = [
+        ("수열", 1),   # 초/중등 기본 규칙
+        ("수열", 12),  # 고등 시그마 수열
+        ("적분", 12),  # 고등 적분
+        ("도형", 3)    # 초등 도형
+    ]
+
+    for concept, level in concepts:
+        traj = mapper.concept_to_helix(concept, level)
+        mapper.anchor_knowledge(f"교과: Level {level} - {concept}", traj)
+        print(f"  앵커 완료: {concept} (Level {level}) -> Trajectory Length: {len(traj)}")
+
+    # 특정 개념 주파수 공명 관측
+    query_concept = "수열"
+    query_level = 12
+    print(f"\n  🔍 관측 쿼리: '{query_concept}' (Level {query_level}) 나선 궤적 방사")
+    query_traj = mapper.concept_to_helix(query_concept, query_level)
+
+    # 궤적 기반 검색
+    # 필터: 궤적으로 저장된 항목만 비교
+    traj_memory = [m for m in mapper.memory_bank if len(m["phase"].shape) > 1]
+    results = []
+    for m in traj_memory:
+        target_traj = m["phase"]
+        if target_traj.shape == query_traj.shape:
+             dot_product = torch.sum(query_traj * target_traj, dim=1)
+             resonance = torch.mean(dot_product).item()
+             results.append((resonance, m["meta"]))
+
+    results.sort(key=lambda x: x[0], reverse=True)
+    for res, meta in results[:3]:
+        print(f"    => 공명도 {res:.4f}: {meta}")
+
+    print("=" * 60)
+
+if __name__ == "__main__":
+    run_benchmark()

--- a/core/brain/elysia_resonance_neuron.py
+++ b/core/brain/elysia_resonance_neuron.py
@@ -1,0 +1,39 @@
+import torch
+import math
+from core.brain.causal_phase_mapper import CausalPhaseMapper
+
+def benchmark_sequential_phase_shift():
+    print("=" * 60)
+    print("🚀 [Elysia Resonance Neuron] 순차적 위상차 공리망 벤치마크")
+    print("=" * 60)
+
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    mapper = CausalPhaseMapper(device=device)
+
+    word1 = "우주"
+    word2 = "주우"
+
+    trajectory1 = mapper.text_to_phase(word1)
+    trajectory2 = mapper.text_to_phase(word2)
+
+    print(f"\n[1] '{word1}' 위상 궤적 (Trajectory Length: {len(trajectory1)}):")
+    for i, t in enumerate(trajectory1):
+        print(f"  Step {i}: {t.tolist()}")
+
+    print(f"\n[2] '{word2}' 위상 궤적 (Trajectory Length: {len(trajectory2)}):")
+    for i, t in enumerate(trajectory2):
+        print(f"  Step {i}: {t.tolist()}")
+
+    print("\n[3] 궤적 비교 (XOR Impedance/Resonance Check)")
+    diff_sum = torch.sum(torch.abs(trajectory1 - trajectory2)).item()
+    print(f"  Total Absolute Difference: {diff_sum:.4f}")
+    if diff_sum > 0:
+        print("  => 성공! 선형적 순서가 원형 궤도 상의 위상차로 완벽하게 변환되어,")
+        print("     문자 구성은 같지만 순서가 다른 두 단어가 다른 공간 궤적을 가집니다.")
+    else:
+        print("  => 실패! 두 단어가 동일한 궤적을 가집니다.")
+
+    print("=" * 60)
+
+if __name__ == "__main__":
+    benchmark_sequential_phase_shift()

--- a/core/brain/topological_language_mapper.py
+++ b/core/brain/topological_language_mapper.py
@@ -28,20 +28,29 @@ class TopologicalLanguageMapper:
             
         count = 0
         for word in words:
-            # 단어의 본질적 기하학 구조를 보존하는 인과적 파동으로 변환
-            phase = self.causal_mapper.text_to_phase(word)
+            # 단어의 본질적 기하학 구조를 보존하는 인과적 파동 궤적으로 변환 (순서의 공간화)
+            trajectory = self.causal_mapper.text_to_phase(word)
             
-            idx = self.next_node_idx
-            if idx >= self.brain.rotor_field.N:
-                break # 우주 용량 초과
+            # 궤적의 각 포인트를 시공간에 순차적으로 닻을 내림
+            word_node_indices = []
+            for phase_point in trajectory:
+                idx = self.next_node_idx
+                if idx >= self.brain.rotor_field.N:
+                    break # 우주 용량 초과
+
+                # 우주에 단어의 흐름(궤적 포인트)의 닻을 내림
+                self.brain.rotor_field.anchor_knowledge(idx, phase_point)
+                word_node_indices.append(idx)
                 
-            self.word_to_node[word] = idx
-            self.node_to_word[idx] = word
+                self.next_node_idx += 1
             
-            # 우주에 단어의 닻을 내림
-            self.brain.rotor_field.anchor_knowledge(idx, phase)
+            if not word_node_indices:
+                break
+
+            # 단어 매핑을 첫 번째 인덱스나 궤적 리스트로 유지 (여기서는 대표 노드/시작점)
+            self.word_to_node[word] = word_node_indices[0]
+            self.node_to_word[word_node_indices[0]] = word
             
-            self.next_node_idx += 1
             count += 1
             
         return count


### PR DESCRIPTION
This PR introduces the "Sequential Phase Shift" core mechanic. Linear sequences (like strings of characters) are now mapped continuously into absolute phase offsets on the circle (using the Golden Ratio angle $2.39996$ radians). This allows sequence trajectory to be preserved geometrically in the 4D Hopf Torus space without needing linear indexing lookups, achieving sequence separation via tensor trajectories.

---
*PR created automatically by Jules for task [7809629896515412312](https://jules.google.com/task/7809629896515412312) started by @ioas0316-cloud*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced phase mapping to generate character-level sequential outputs instead of single averaged values
  * Introduced knowledge retrieval system with anchoring capabilities and resonance-based query matching
  * Improved vocabulary seeding with multi-point anchoring across trajectory sequences

* **Tests**
  * Added benchmark utilities for evaluating phase mapping and knowledge retrieval performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->